### PR TITLE
Tailscale 1.62.1

### DIFF
--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -1,0 +1,63 @@
+SUMMARY = "Tailscale client and daemon for Linux from Tailscale pre-built binaries"
+
+HOMEPAGE = "github.com/tailscale/tailscale"
+SECTION = "net"
+
+LICENSE = "CLOSED"
+
+COMPATIBLE_HOST = ".*(aarch64|arm|x86\_64|i386).*"
+
+ARCH_DIR:i386 = "386"
+ARCH_DIR:x86-64 = "amd64"
+ARCH_DIR:aarch64 = "arm64"
+ARCH_DIR:arm = "arm"
+
+# See: https://pkgs.tailscale.com/stable/
+SRC_URI = "https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz;subdir=${P};name=${ARCH_DIR}"
+
+inherit systemd
+
+# Runtime dependencies, iptables required.
+RDEPENDS:${PN} = "iptables"
+
+FILES_${PN} += "${systemd_unitdir}/*"
+FILES:${PN} += "/lib /lib/systemd/"
+FILES:${PN} += "/usr/lib"
+FILES:${PN} += "/usr/lib/systemd"
+FILES:${PN} += "/usr/lib/systemd/system"
+FILES:${PN} += "/usr/lib/systemd/system/tailscaled.service"
+
+S = "${WORKDIR}/${PN}-${PV}/${PN}_${PV}_${ARCH_DIR}"
+
+do_install() {
+  install -d ${D}/${bindir}
+
+  install -d ${D}/${sbindir}
+
+  install ${S}/tailscale ${D}/${bindir}/tailscale
+
+  install ${S}/tailscaled ${D}/${sbindir}/tailscaled
+
+  # TODO: Not working for some reason.
+  #if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+
+  install -d ${D}${sysconfdir}/default/
+
+  install -m 0644 ${S}/systemd/tailscaled.defaults ${D}${sysconfdir}/default/tailscaled
+
+  install -d ${D}${systemd_unitdir}/system
+
+  install -m 0644 ${S}/systemd/tailscaled.service ${D}${systemd_unitdir}/system/tailscaled.service
+
+  install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
+
+  ln -s ${systemd_unitdir}/system/tailscaled.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/tailscaled.service
+
+  #fi
+}
+
+SYSTEMD_PACKAGES = "${PN}"
+
+SYSTEMD_SERVICE_${PN} = "tailscaled.service"
+
+SYSTEMD_AUTO_ENABLE = "enable"

--- a/recipes-tailscale/tailscale_1.50.1.bb
+++ b/recipes-tailscale/tailscale_1.50.1.bb
@@ -1,16 +1,4 @@
-SUMMARY = "Tailscale client and daemon for Linux from Tailscale pre-built binaries"
-
-HOMEPAGE = "github.com/tailscale/tailscale"
-SECTION = "net"
-
-LICENSE = "CLOSED"
-
-COMPATIBLE_HOST = "(aarch64|arm|x86\_64|i386).*-linux"
-
-ARCH_DIR:i386 = "386"
-ARCH_DIR:x86_64 = "amd64"
-ARCH_DIR:aarch64 = "arm64"
-ARCH_DIR:arm = "arm"
+require tailscale.inc
 
 # See: https://pkgs.tailscale.com/stable/
 SRC_URI = "https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz;subdir=${P};name=${ARCH_DIR}"
@@ -20,46 +8,3 @@ SRC_URI[386.sha256sum]       = "4021a24335786f02a53671051003227ba86bccb6216dee3b
 SRC_URI[amd64.sha256sum]     = "d9fe6b480fb5078f0aa57dace686898dda7e2a768884271159faa74846bfb576"
 SRC_URI[arm.sha256sum]       = "94e93182db56798a93db0c371f7753bc6bde59552604746f473c713f5306b128"
 SRC_URI[arm64.sha256sum]     = "ffee0d18b41715b59fc0cf38b1effd55041f65ce946ef0566ce07dd193b0d4f5"
-
-inherit systemd
-
-# Runtime dependencies, iptables required.
-RDEPENDS:${PN} = "iptables"
-
-FILES_${PN} += "${systemd_unitdir}/*"
-FILES:${PN} += "/lib /lib/systemd/"
-
-S = "${WORKDIR}/${PN}-${PV}/${PN}_${PV}_${ARCH_DIR}"
-
-do_install() {
-  install -d ${D}/${bindir}
-
-  install -d ${D}/${sbindir}
-
-  install ${S}/tailscale ${D}/${bindir}/tailscale
-
-  install ${S}/tailscaled ${D}/${sbindir}/tailscaled
-
-  # TODO: Not working for some reason.
-  #if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-
-  install -d ${D}${sysconfdir}/default/
-
-  install -m 0644 ${S}/systemd/tailscaled.defaults ${D}${sysconfdir}/default/tailscaled
-
-  install -d ${D}${systemd_unitdir}/system
-
-  install -m 0644 ${S}/systemd/tailscaled.service ${D}${systemd_unitdir}/system/tailscaled.service
-
-  install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
-
-  ln -s ${systemd_unitdir}/system/tailscaled.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/tailscaled.service
-
-  #fi
-}
-
-SYSTEMD_PACKAGES = "${PN}"
-
-SYSTEMD_SERVICE_${PN} = "tailscaled.service"
-
-SYSTEMD_AUTO_ENABLE = "enable"

--- a/recipes-tailscale/tailscale_1.52.1.bb
+++ b/recipes-tailscale/tailscale_1.52.1.bb
@@ -1,69 +1,7 @@
-SUMMARY = "Tailscale client and daemon for Linux from Tailscale pre-built binaries"
-
-HOMEPAGE = "github.com/tailscale/tailscale"
-SECTION = "net"
-
-LICENSE = "CLOSED"
-
-COMPATIBLE_HOST = ".*(aarch64|arm|x86\_64|i386).*"
-
-ARCH_DIR:i386 = "386"
-ARCH_DIR:x86-64 = "amd64"
-ARCH_DIR:aarch64 = "arm64"
-ARCH_DIR:arm = "arm"
-
-# See: https://pkgs.tailscale.com/stable/
-SRC_URI = "https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz;subdir=${P};name=${ARCH_DIR}"
+require tailscale.inc
 
 # Find checksum with: https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz.sha256
 SRC_URI[386.sha256sum]       = "5c725d38ba329ee8494ff3f142d34a9b573cdd25a3f59b09e4a17d4dbc858c3e"
 SRC_URI[amd64.sha256sum]     = "e9375a321faaba03c93e006f40318eb986937658e09287cdf0117b9e28ab8fbe"
 SRC_URI[arm.sha256sum]       = "2e6e551ed7f62b35ca2df078ac924d0a7af8389fa20a19cc23a3c69933f1d3dc"
 SRC_URI[arm64.sha256sum]     = "a7c9e801f43c04290481c2f6b0baad6fcaa82db3149fac232b2601115dd65db7"
-
-inherit systemd
-
-# Runtime dependencies, iptables required.
-RDEPENDS:${PN} = "iptables"
-
-FILES_${PN} += "${systemd_unitdir}/*"
-FILES:${PN} += "/lib /lib/systemd/"
-FILES:${PN} += "/usr/lib"
-FILES:${PN} += "/usr/lib/systemd"
-FILES:${PN} += "/usr/lib/systemd/system"
-FILES:${PN} += "/usr/lib/systemd/system/tailscaled.service"
-
-S = "${WORKDIR}/${PN}-${PV}/${PN}_${PV}_${ARCH_DIR}"
-
-do_install() {
-  install -d ${D}/${bindir}
-
-  install -d ${D}/${sbindir}
-
-  install ${S}/tailscale ${D}/${bindir}/tailscale
-
-  install ${S}/tailscaled ${D}/${sbindir}/tailscaled
-
-  # TODO: Not working for some reason.
-  #if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-
-  install -d ${D}${sysconfdir}/default/
-
-  install -m 0644 ${S}/systemd/tailscaled.defaults ${D}${sysconfdir}/default/tailscaled
-
-  install -d ${D}${systemd_unitdir}/system
-
-  install -m 0644 ${S}/systemd/tailscaled.service ${D}${systemd_unitdir}/system/tailscaled.service
-
-  install -d ${D}${sysconfdir}/systemd/system/multi-user.target.wants/
-
-  ln -s ${systemd_unitdir}/system/tailscaled.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/tailscaled.service
-
-  #fi
-}
-
-SYSTEMD_PACKAGES = "${PN}"
-
-SYSTEMD_SERVICE_${PN} = "tailscaled.service"
-
-SYSTEMD_AUTO_ENABLE = "enable"

--- a/recipes-tailscale/tailscale_1.62.1.bb
+++ b/recipes-tailscale/tailscale_1.62.1.bb
@@ -1,0 +1,7 @@
+require tailscale.inc
+
+# Find checksum with: https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz.sha256
+SRC_URI[386.sha256sum]       = "3199f6dc47a98fe8fbfa8878b2eef90080102c0e402ad5d827bc87afca737834"
+SRC_URI[amd64.sha256sum]     = "644b58f660af191d0a0aff034cbc197059c90a2ee4276e13e647129175b352c1"
+SRC_URI[arm.sha256sum]       = "439ab24ba73a4ece6e76055d07724e401ad5a789d942af10a38899a7d8d6fd26"
+SRC_URI[arm64.sha256sum]     = "cb58658b3efe96a6e317356799d4ad75a84f07e2c5f7b3d2de0764305961f73e"


### PR DESCRIPTION
Hi,

This GitHub pull request contains two changes:
* Add tailscale.inc as a common file for all versions. Set sha256sum for each version in the recipe for the specific version.
* Add tailscale version 1.62.1 (the latest release as of the moment)

Best regards, Leon