### PR TITLE
Add scarthgap to layer compatibility list

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-tailscale = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tailscale = "6"
 
 LAYERDEPENDS_meta-tailscale = "core"
-LAYERSERIES_COMPAT_meta-tailscale = "nanbield kirkstone"
+LAYERSERIES_COMPAT_meta-tailscale = "scarthgap nanbield kirkstone"


### PR DESCRIPTION
I have been using meta-tailscale with scarthgap since mid July without issue. Would be nice to have this upstream and not have to patch.