### PR TITLE
Fix: Add iptables to dependencies, to stop runtime errors

### DIFF
--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -53,6 +53,7 @@ do_install() {
 
   ln -s ${systemd_unitdir}/system/tailscaled.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/tailscaled.service
 
+  #fi
 }
 
 DEPENDS += "iptables"

--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -53,8 +53,10 @@ do_install() {
 
   ln -s ${systemd_unitdir}/system/tailscaled.service ${D}${sysconfdir}/systemd/system/multi-user.target.wants/tailscaled.service
 
-  #fi
 }
+
+DEPENDS += "iptables"
+RDEPENDS:${PN} += "iptables"
 
 SYSTEMD_PACKAGES = "${PN}"
 


### PR DESCRIPTION
This solves #10 

DEPENDS and RDEPENDS now include iptables, which is a dependency of tailscale.

Im not too sure if this is a dependency across all versions, so as a safe bet its placed at the universal '.inc' 