### PR TITLE
fix: Correct override syntax

### DIFF
--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -61,6 +61,6 @@ RDEPENDS:${PN} += "iptables"
 
 SYSTEMD_PACKAGES = "${PN}"
 
-SYSTEMD_SERVICE_${PN} = "tailscaled.service"
+SYSTEMD_SERVICE:${PN} = "tailscaled.service"
 
 SYSTEMD_AUTO_ENABLE = "enable"


### PR DESCRIPTION
Correct the override syntax in tailscale.inc from pre Honister to current.
