### PR TITLE
Update tailscale version and support Whinlatter

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-tailscale = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-tailscale = "6"
 
 LAYERDEPENDS_meta-tailscale = "core"
-LAYERSERIES_COMPAT_meta-tailscale = "scarthgap nanbield kirkstone"
+LAYERSERIES_COMPAT_meta-tailscale = "scarthgap nanbield kirkstone whinlatter"

--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -7,6 +7,11 @@ LICENSE = "CLOSED"
 
 INHIBIT_DEFAULT_DEPS = "1"
 
+# tailscale ships pre-built binaries, so stripping and debug-split would fail
+# because binutils cross tools are not in the sysroot.
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
 ARCH_DIR ?= "Unsupported"
 ARCH_DIR:i386 = "386"
 ARCH_DIR:x86-64 = "amd64"
@@ -18,7 +23,7 @@ SRC_URI = "https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz;sub
 
 inherit systemd
 
-# Pre-built binaries — no compiler needed (INHIBIT_DEFAULT_DEPS = "1" is already set)
+# Pre-built binaries — no compiler needed, no stripping or debug splitting.
 # Runtime dependencies, iptables required.
 RDEPENDS:${PN} = "iptables"
 

--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -18,8 +18,7 @@ SRC_URI = "https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz;sub
 
 inherit systemd
 
-# These are needed to do the package splitting
-DEPENDS:append = " virtual/${HOST_PREFIX}gcc virtual/${HOST_PREFIX}compilerlibs virtual/libc"
+# Pre-built binaries — no compiler needed (INHIBIT_DEFAULT_DEPS = "1" is already set)
 # Runtime dependencies, iptables required.
 RDEPENDS:${PN} = "iptables"
 
@@ -37,7 +36,7 @@ SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "tailscaled.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
-S = "${WORKDIR}/${PN}-${PV}/${PN}_${PV}_${ARCH_DIR}"
+S = "${UNPACKDIR}/${PN}-${PV}/${PN}_${PV}_${ARCH_DIR}"
 
 do_install() {
   install -d ${D}/${bindir}

--- a/recipes-tailscale/tailscale_1.94.2.bb
+++ b/recipes-tailscale/tailscale_1.94.2.bb
@@ -1,0 +1,7 @@
+require tailscale.inc
+
+# Find checksum with: https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz.sha256
+SRC_URI[386.sha256sum]       = "34f969c6dd7dd824c1395ea8efc537f9843b62b4ff1719a70e0622b8c4b31e1d"
+SRC_URI[amd64.sha256sum]     = "c6f99a5d774c7783b56902188d69e9756fc3dddfb08ac6be4cb2585f3fecdc32"
+SRC_URI[arm.sha256sum]       = "e5d1489c8315c88deb7d0104a9eb16a116938fff9455f8232703a1a1bf957b65"
+SRC_URI[arm64.sha256sum]     = "76300e808c57eb7853090d69c8bd8806e86341862e244183f6611f9105799bba"

--- a/recipes-tailscale/tailscale_1.96.4.bb
+++ b/recipes-tailscale/tailscale_1.96.4.bb
@@ -1,0 +1,7 @@
+require tailscale.inc
+
+# Find checksum with: https://pkgs.tailscale.com/stable/tailscale_${PV}_${ARCH_DIR}.tgz.sha256
+SRC_URI[386.sha256sum]       = "c66c097398f49088c9fdcfb4c37b9e195a135bc7315ecbe083655b76dc321c70"
+SRC_URI[amd64.sha256sum]     = "a1cba18826b1f91cb25ef7f5b8259b5258339b42db7867af9269e21829ea78cc"
+SRC_URI[arm.sha256sum]       = "6c8731f096147aaf9e187b39f892692fb2bd56dc2eb1fb8fd06982164f339869"
+SRC_URI[arm64.sha256sum]     = "a27249bc70d7b37a68f8be7f5c4507ea5f354e592dce43cb5d4f3e742b313c3c"


### PR DESCRIPTION
- Update tailscale to version 1.96.4
- Support Whinlatter