### PR TITLE
Fix compatibility around UNPACKDIR.

### DIFF
--- a/recipes-tailscale/tailscale.inc
+++ b/recipes-tailscale/tailscale.inc
@@ -41,6 +41,15 @@ SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "tailscaled.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
+# UNPACKDIR was introduced in Styhead (5.1) and its absence in previous versions (e.g. Scarthgap 5.0) leaves S
+# unexpanded, causing do_unpack to fail. Conditionally setting it ensures compatibility with older versions and avoids
+# interfering with Whinlatter (5.3) and later where the WORKDIR auto-move shim is removed and UNPACKDIR is mandatory.
+# See: https://docs.yoctoproject.org/dev/migration-guides/migration-5.3.html#workdir-changes.
+python () {
+  if not d.getVar("UNPACKDIR"):
+    d.setVar("UNPACKDIR", "${WORKDIR}")
+}
+
 S = "${UNPACKDIR}/${PN}-${PV}/${PN}_${PV}_${ARCH_DIR}"
 
 do_install() {


### PR DESCRIPTION
Pulling the latest changes broke my Scarthgap-based distro:

```
ERROR: tailscale-1.96.4-r0 do_unpack: Directory name ${@d.getVar('S') contains unexpanded bitbake variable. This may cause build failures and WORKDIR polution.
```

After investigating, it seems the `UNPACKDIR` variable has been brought in, which complies with later versions but is not defined in Scarthgap and previous. Since this layer advertises compatibility with a wide range of versions (Kirkstone through Whinlatter) on a single branch, I'm proposing the following patch to ensure `UNPACKDIR` is defined on Scarthgap and earlier while not overriding behavior in newer versions where it is.

In my case, it's desirable to stick with an LTS release (Scarthgap) and still have a recent Tailscale version. Making dedicated branches also seems a bit overkill for the scope of this layer and would add more of maintenance burden.

Thanks for the work maintaining this layer!